### PR TITLE
Add logging to the deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk --no-cache add --update \
     postgresql-client \
     postgresql-dev \
     build-base \
-    linux-headers
+    linux-headers \
+    curl
 
 # Install only Python requirements
 COPY setup.py README.rst CHANGES.rst /code/

--- a/logging_config.yml
+++ b/logging_config.yml
@@ -8,20 +8,27 @@ handlers:
     class: logging.StreamHandler
     formatter: f
     level: DEBUG
-  logstash:
-    class: logstash_async.handler.AsynchronousLogstashHandler
-    database_path: logstash.db
-    host: localhost
-    level: DEBUG
-    port: 5001
-    transport: logstash_async.transport.TcpTransport
+
+# Example of adding a logstash handler
+#
+# Install with: pip install python-logstash-async
+#
+#  logstash:
+#    class: logstash_async.handler.AsynchronousLogstashHandler
+#    database_path: logstash.db
+#    host: localhost
+#    level: DEBUG
+#    port: 5001
+#    transport: logstash_async.transport.TcpTransport
+
 loggers:
   renga:
     handlers:
-    - console
+      - console
     level: INFO
+    propagate: False
   renga.deployer.engines:
     handlers:
-    - console
-    - logstash
+      - console
     level: DEBUG
+    propagate: False

--- a/logging_config.yml
+++ b/logging_config.yml
@@ -1,0 +1,27 @@
+# logging configuration using a logstash async logger
+version: 1
+formatters:
+  f:
+    format: '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: f
+    level: DEBUG
+  logstash:
+    class: logstash_async.handler.AsynchronousLogstashHandler
+    database_path: logstash.db
+    host: localhost
+    level: DEBUG
+    port: 5001
+    transport: logstash_async.transport.TcpTransport
+loggers:
+  renga:
+    handlers:
+    - console
+    level: INFO
+  renga.deployer.engines:
+    handlers:
+    - console
+    - logstash
+    level: DEBUG

--- a/renga_deployer/app.py
+++ b/renga_deployer/app.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 """Renga Deployer application."""
 
-import logging
 import os
 import sys
 from urllib.parse import urlparse
@@ -29,7 +28,7 @@ from flask_babelex import Babel
 from jose import jwt
 from sqlalchemy_utils import functions
 
-from . import config
+from . import config, logging
 from .ext import RengaDeployer
 from .models import db
 
@@ -82,4 +81,5 @@ def create_app(**kwargs):
 
         db.create_all()
         logger.debug('Database initialized.')
+
     return api.app

--- a/renga_deployer/app.py
+++ b/renga_deployer/app.py
@@ -73,6 +73,9 @@ def create_app(**kwargs):
         api.app.wsgi_app = ProxyFix(
             api.app.wsgi_app, num_proxies=api.app.config['WSGI_NUM_PROXIES'])
 
+    # setup logging
+    logging.setup_logging(api.app.config['RENGA_LOGGING_CONFIG'])
+
     # create database and tables
     with api.app.app_context():
         if not functions.database_exists(db.engine.url):

--- a/renga_deployer/app.py
+++ b/renga_deployer/app.py
@@ -33,7 +33,7 @@ from . import config
 from .ext import RengaDeployer
 from .models import db
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('renga.deployer.app')
 
 
 def create_app(**kwargs):
@@ -78,7 +78,8 @@ def create_app(**kwargs):
     with api.app.app_context():
         if not functions.database_exists(db.engine.url):
             functions.create_database(db.engine.url)
+            logger.debug('Database created.')
 
         db.create_all()
-
+        logger.debug('Database initialized.')
     return api.app

--- a/renga_deployer/authorization.py
+++ b/renga_deployer/authorization.py
@@ -50,8 +50,12 @@ def check_token(*scopes):
             # verify the token
             if not access_token or not access_token.lower().startswith(
                     'bearer '):
-                logger.warn('Authorization token not found in headers.',
-                            extra={'g': g, 'request': request.json()})
+                logger.warn(
+                    'Authorization token not found in headers.',
+                    extra={'g': g,
+                           'request': {
+                               'headers': request.headers
+                           }})
                 raise Unauthorized('Authorization token not found in headers.')
 
             access_token = access_token[len('bearer '):]
@@ -71,9 +75,13 @@ def check_token(*scopes):
             scope_key = current_app.config['DEPLOYER_TOKEN_SCOPE_KEY']
             if scope_key and not all(
                     s in auth.get(scope_key, []) for s in scopes):
-                logger.warn('Insufficient scope.',
-                            extra={'g': g, 'request': request.json(),
-                                   'scope_key': scope_key})
+                logger.warn(
+                    'Insufficient scope.',
+                    extra={
+                        'g': g,
+                        'request': {'headers': request.headers},
+                        'scope_key': scope_key
+                    })
                 raise Unauthorized('Insufficient scope.')
 
             return function(*args, **kwargs)

--- a/renga_deployer/config.py
+++ b/renga_deployer/config.py
@@ -83,6 +83,9 @@ RENGA_AUTHORIZATION_CLIENT_SECRET = None
 RENGA_AUTHORIZATION_CLIENT_ID = None
 """Client id for fetching the service access token."""
 
+RENGA_LOGGING_CONFIG = None
+"""Logging configuration file path."""
+
 SQLALCHEMY_DATABASE_URI = 'sqlite:///deployer.db'
 """The URI of the database to be used for preserving internal state."""
 

--- a/renga_deployer/deployer.py
+++ b/renga_deployer/deployer.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Deployer sub-module."""
 
+import logging
 import os
 
 from blinker import Namespace
@@ -29,6 +30,8 @@ deployer_signals = Namespace()
 context_created = deployer_signals.signal('context-created')
 execution_created = deployer_signals.signal('execution-created')
 execution_launched = deployer_signals.signal('execution-launched')
+
+logger = logging.getLogger('renga.deployer.deployer')
 
 
 class Deployer(object):

--- a/renga_deployer/engines.py
+++ b/renga_deployer/engines.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Engine sub-module."""
 
+import logging
 import os
 import shlex
 import time
@@ -26,6 +27,8 @@ from werkzeug.utils import cached_property
 
 from .models import Execution
 from .utils import decode_bytes, resource_available
+
+logger = logging.getLogger('renga.deployer.engines')
 
 
 class Engine(object):
@@ -64,6 +67,9 @@ class DockerEngine(Engine):
     def launch(self, execution, **kwargs):
         """Launch a docker container with the context image."""
         context = execution.context
+
+        logger.debug(
+            'Launching execution context')
 
         if context.spec.get('ports'):
             ports = {port: None for port in context.spec.get('ports')}

--- a/renga_deployer/logging.py
+++ b/renga_deployer/logging.py
@@ -17,7 +17,8 @@
 # limitations under the License.
 """Renga Logging."""
 
-import logging
+
+from logging import DEBUG, INFO, getLogger
 from logging.config import dictConfig
 
 import yaml
@@ -41,16 +42,16 @@ else:
             'console': {
                 'class': 'logging.StreamHandler',
                 'formatter': 'f',
-                'level': logging.DEBUG
+                'level': DEBUG
             },
         },
         'loggers': {
             'renga': {
                 'handlers': ['console'],
-                'level': logging.INFO
+                'level': INFO
             }
         }
     })
 
-logger = logging.getLogger('renga.deployer.logging')
+logger = getLogger('renga.deployer.logging')
 logger.debug('Logging initialized.')

--- a/renga_deployer/logging.py
+++ b/renga_deployer/logging.py
@@ -17,41 +17,46 @@
 # limitations under the License.
 """Renga Logging."""
 
-
+import os
 from logging import DEBUG, INFO, getLogger
 from logging.config import dictConfig
 
 import yaml
 
-from . import config
 
-conf = config.from_env(config)
+def setup_logging(conf):
+    """Configure logging for the deployer app."""
+    if conf and os.path.exists(os.path.dirname(conf)):
+        with open(conf, 'r') as fp:
+            dictConfig(yaml.load(fp))
 
-if conf.get('RENGA_LOGGING_CONFIG'):
-    with open(conf['RENGA_LOGGING_CONFIG'], 'r') as fp:
-        dictConfig(yaml.load(fp))
-else:
-    dictConfig({
-        'version': 1,
-        'formatters': {
-            'f': {
-                'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-            }
-        },
-        'handlers': {
-            'console': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'f',
-                'level': DEBUG
+    elif isinstance(conf, dict):
+        dictConfig(conf)
+
+    else:
+        # no configuration provided, use a default
+        dictConfig({
+            'version': 1,
+            'formatters': {
+                'f': {
+                    'format':
+                    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+                }
             },
-        },
-        'loggers': {
-            'renga': {
-                'handlers': ['console'],
-                'level': INFO
+            'handlers': {
+                'console': {
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'f',
+                    'level': DEBUG
+                },
+            },
+            'loggers': {
+                'renga': {
+                    'handlers': ['console'],
+                    'level': INFO
+                }
             }
-        }
-    })
+        })
 
-logger = getLogger('renga.deployer.logging')
-logger.debug('Logging initialized.')
+    logger = getLogger('renga.deployer.logging')
+    logger.debug('Logging initialized.')

--- a/renga_deployer/logging.py
+++ b/renga_deployer/logging.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renga Logging."""
+
+import logging
+from logging.config import dictConfig
+
+import yaml
+
+from . import config
+
+conf = config.from_env(config)
+
+if conf.get('RENGA_LOGGING_CONFIG'):
+    with open(conf['RENGA_LOGGING_CONFIG'], 'r') as fp:
+        dictConfig(yaml.load(fp))
+else:
+    dictConfig({
+        'version': 1,
+        'formatters': {
+            'f': {
+                'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+            }
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'f',
+                'level': logging.DEBUG
+            },
+        },
+        'loggers': {
+            'renga': {
+                'handlers': ['console'],
+                'level': logging.INFO
+            }
+        }
+    })
+
+logger = logging.getLogger('renga.deployer.logging')
+logger.debug('Logging initialized.')

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ install_requires = [
     'requests>=2.18.1',
     'six>=1.10.0',
     'sqlalchemy-utils>=0.32.14',
+    'python-logstash-async>=1.3.1'
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ extras_require = {
     'wsgi': [
         'uwsgi>=2.0.15',
     ],
+    'logging': [
+        'python-logstash-async>=1.3.1',
+    ],
 }
 
 extras_require['all'] = []
@@ -74,7 +77,6 @@ install_requires = [
     'requests>=2.18.1',
     'six>=1.10.0',
     'sqlalchemy-utils>=0.32.14',
-    'python-logstash-async>=1.3.1'
 ]
 
 packages = find_packages()

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -18,6 +18,7 @@
 """Contrib modules tests."""
 
 import json
+from collections import namedtuple
 
 import pytest
 import requests
@@ -33,18 +34,29 @@ from renga_deployer.utils import join_url
 r_get = requests.get
 r_post = requests.post
 
+Request = namedtuple('Request', ['body', 'headers', 'url'])
+
 
 class Response(object):
     """Fake response."""
 
-    def __init__(self, data, status_code):
+    def __init__(self, content, status_code, headers=None):
         """Initialize fake response object with a json."""
-        self.data = data
+        self.content = content
         self.status_code = status_code
+        self.headers = headers or {'header': 'some-header'}
 
     def json(self):
         """Return json."""
-        return self.data
+        return self.content
+
+    @property
+    def request(self):
+        """Return a fake request object."""
+        return Request(
+            body='1234',
+            headers={'header': 'some-header'},
+            url='http://example.com')
 
 
 #


### PR DESCRIPTION
Implements logging in the deployer using the standard python logging module. 

The user can specify the location of a yaml or json logging configuration file using the `RENGA_LOGGING_CONFIG` environment variable. A sample logging config file is included with the deployer, but in general we will have one config file to set up logging for all python-based services. 

closes #4 
closes #41 