### PR TITLE
remove interactive=true

### DIFF
--- a/renga_deployer/engines.py
+++ b/renga_deployer/engines.py
@@ -77,8 +77,7 @@ class DockerEngine(Engine):
         context = execution.context
 
         if context.spec.get('ports'):
-            ports = {port: None for port in filter(
-                None, context.spec.get('ports'))}
+            ports = {port: None for port in context.spec.get('ports')}
         else:
             ports = None
 
@@ -195,7 +194,9 @@ class K8SEngine(Engine):
                    'execution': execution_schema.dump(execution).data,
                    'context': context_schema.dump(execution.context).data})
 
-        if context.spec.get('interactive'):
+        # assume that if the user specified a port to open, they want
+        # it available from the outside
+        if context.spec.get('ports'):
             # To expose an interactive job, we need to start a service.
             # We use the job controller-uid to link the service.
             api = self._kubernetes.client.CoreV1Api()
@@ -295,7 +296,7 @@ class K8SEngine(Engine):
         if context.spec.get('ports'):
             spec['containers'][0]['ports'] = [{
                 'containerPort': int(port)
-            } for port in filter(None, context.spec['ports'])]
+            } for port in context.spec['ports']]
 
         if context.spec.get('command'):
             command = shlex.split(context.spec['command'])

--- a/renga_deployer/models.py
+++ b/renga_deployer/models.py
@@ -59,6 +59,8 @@ class Context(db.Model, Timestamp):
     @classmethod
     def create(cls, spec=None):
         """Create a new context."""
+        if 'ports' in spec:
+            spec['ports'] = list(filter(None, spec['ports']))
         context = cls(spec=spec, id=uuid.uuid4())
         return context
 

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -68,7 +68,6 @@ def test_open_port(app, engine, deployer):
         'ports': [
             '9999',
         ],
-        'interactive': 'true'
     })
     execution = deployer.launch(context, engine=engine)
 


### PR DESCRIPTION
Assume the user wants to set up a service if they specify a port in the context. 

Side effect: filter out empty strings from port spec when creating the context.

fixes #54 